### PR TITLE
feat: #40 Wiki 기본 페이지(리스트/본문/backlinks) 구현

### DIFF
--- a/app/wiki/[slug]/page.tsx
+++ b/app/wiki/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { MDXContent } from '@/components/mdx-content'
+import { formatWikiDate } from '@/lib/wiki-date'
 import { getWikiPost, getWikiPosts } from '@/lib/wiki-posts'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
@@ -7,14 +8,6 @@ type WikiDetailPageProps = {
   params: Promise<{
     slug: string
   }>
-}
-
-const formatDate = (value: string) => {
-  return new Date(value).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  })
 }
 
 export function generateStaticParams() {
@@ -56,7 +49,7 @@ export default async function WikiDetailPage({ params }: WikiDetailPageProps) {
             </span>
           ))}
           <span className="not-prose text-xs text-zinc-500 dark:text-zinc-400">
-            업데이트: {formatDate(post.updatedAt)}
+            업데이트: {formatWikiDate(post.updatedAt)}
           </span>
         </div>
         <div className="mt-8">

--- a/app/wiki/[slug]/page.tsx
+++ b/app/wiki/[slug]/page.tsx
@@ -1,0 +1,76 @@
+import { MDXContent } from '@/components/mdx-content'
+import { getWikiPost, getWikiPosts } from '@/lib/wiki-posts'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+type WikiDetailPageProps = {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+const formatDate = (value: string) => {
+  return new Date(value).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}
+
+export function generateStaticParams() {
+  return getWikiPosts().map((post) => ({
+    slug: post.slugAsParams,
+  }))
+}
+
+export default async function WikiDetailPage({ params }: WikiDetailPageProps) {
+  const { slug } = await params
+  const post = getWikiPost(slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  const backlinks: string[] = []
+
+  return (
+    <main className="mt-24 pb-20">
+      <div className="mb-4">
+        <Link
+          href="/wiki"
+          className="text-sm text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+        >
+          {'<'} Wiki
+        </Link>
+      </div>
+      <article className="prose prose-gray max-w-none dark:prose-invert prose-h1:text-xl prose-h1:font-medium prose-h2:mt-12 prose-h2:text-lg prose-h2:font-medium prose-h3:text-base prose-h3:font-medium prose-pre:border prose-pre:border-zinc-200 prose-pre:bg-zinc-100 prose-pre:text-zinc-800 dark:prose-pre:border-zinc-800 dark:prose-pre:bg-zinc-900 dark:prose-pre:text-zinc-100">
+        <h1>{post.title}</h1>
+        {post.description && <p className="mt-2 text-zinc-600">{post.description}</p>}
+        <div className="mt-4 flex flex-wrap gap-2">
+          {post.tags.map((tag) => (
+            <span
+              key={`${post.slugAsParams}-${tag}`}
+              className="not-prose rounded-full bg-zinc-200 px-2 py-0.5 text-xs text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+            >
+              #{tag}
+            </span>
+          ))}
+          <span className="not-prose text-xs text-zinc-500 dark:text-zinc-400">
+            업데이트: {formatDate(post.updatedAt)}
+          </span>
+        </div>
+        <div className="mt-8">
+          <MDXContent code={post.body} />
+        </div>
+      </article>
+      <section className="mt-10 border-t border-zinc-200 pt-6 dark:border-zinc-800">
+        <h2 className="text-base font-semibold">Backlinks</h2>
+        {backlinks.length === 0 && (
+          <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+            연결된 역링크가 아직 없습니다.
+          </p>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/app/wiki/graph/page.tsx
+++ b/app/wiki/graph/page.tsx
@@ -1,0 +1,18 @@
+export const metadata = {
+  title: 'Wiki Graph',
+  description: 'Wiki 그래프 뷰 플레이스홀더 페이지',
+  alternates: {
+    canonical: '/wiki/graph',
+  },
+}
+
+export default function WikiGraphPlaceholderPage() {
+  return (
+    <main className="mt-24 pb-20">
+      <h1 className="text-xl font-semibold">Wiki Graph</h1>
+      <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+        그래프 뷰는 후속 이슈에서 구현 예정입니다.
+      </p>
+    </main>
+  )
+}

--- a/app/wiki/page.tsx
+++ b/app/wiki/page.tsx
@@ -1,0 +1,42 @@
+import { getWikiPosts, getWikiTags } from '@/lib/wiki-posts'
+import Link from 'next/link'
+import { WikiList } from './wiki-list'
+
+export const metadata = {
+  title: 'Wiki',
+  description: '공부 노트와 연결된 문서 목록입니다.',
+  alternates: {
+    canonical: '/wiki',
+  },
+}
+
+export default function WikiIndexPage() {
+  const posts = getWikiPosts().map((post) => ({
+    slug: post.slugAsParams,
+    title: post.title,
+    description: post.description,
+    tags: post.tags,
+    updatedAt: post.updatedAt,
+  }))
+  const tags = getWikiTags()
+
+  return (
+    <main className="mt-24 pb-20">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">Wiki</h1>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+            학습 기록을 연결형 노트로 정리한 문서 목록입니다.
+          </p>
+        </div>
+        <Link
+          href="/wiki/graph"
+          className="shrink-0 rounded-full border border-zinc-300 px-3 py-1.5 text-xs text-zinc-600 transition-colors hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500"
+        >
+          Graph 보기 (준비 중)
+        </Link>
+      </div>
+      <WikiList posts={posts} tags={tags} />
+    </main>
+  )
+}

--- a/app/wiki/wiki-list.tsx
+++ b/app/wiki/wiki-list.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { AnimatedBackground } from '@/components/ui/animated-background'
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+
+export type WikiListItem = {
+  slug: string
+  title: string
+  description?: string
+  tags: string[]
+  updatedAt: string
+}
+
+type WikiListProps = {
+  posts: WikiListItem[]
+  tags: string[]
+}
+
+const formatDate = (value: string) => {
+  return new Date(value).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}
+
+export function WikiList({ posts, tags }: WikiListProps) {
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+
+  const filteredPosts = useMemo(() => {
+    if (!selectedTag) {
+      return posts
+    }
+
+    return posts.filter((post) => post.tags.includes(selectedTag))
+  }, [posts, selectedTag])
+
+  return (
+    <div className="mt-8">
+      <div className="mb-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => setSelectedTag(null)}
+          className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+            selectedTag === null
+              ? 'border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900'
+              : 'border-zinc-300 text-zinc-600 hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500'
+          }`}
+        >
+          전체
+        </button>
+        {tags.map((tag) => (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => setSelectedTag((prevTag) => (prevTag === tag ? null : tag))}
+            className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+              selectedTag === tag
+                ? 'border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900'
+                : 'border-zinc-300 text-zinc-600 hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500'
+            }`}
+          >
+            #{tag}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-col gap-1">
+        <AnimatedBackground
+          enableHover
+          className="h-full w-full rounded-lg bg-zinc-100 dark:bg-zinc-900/80"
+          transition={{
+            type: 'spring',
+            bounce: 0,
+            duration: 0.2,
+          }}
+        >
+          {filteredPosts.map((post) => (
+            <Link
+              key={post.slug}
+              className="-mx-3 rounded-xl px-3 py-3 no-underline hover:no-underline"
+              href={`/wiki/${post.slug}`}
+              data-id={post.slug}
+            >
+              <div className="flex flex-col gap-2">
+                <h4 className="m-0! font-normal dark:text-zinc-100">{post.title}</h4>
+                <div className="flex flex-wrap gap-2">
+                  {post.tags.map((tag) => (
+                    <span
+                      key={`${post.slug}-${tag}`}
+                      className="rounded-full bg-zinc-200 px-2 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+                <p className="mb-0! flex flex-col gap-1 text-zinc-500 dark:text-zinc-400">
+                  {post.description && <span className="text-sm">{post.description}</span>}
+                  <span className="text-xs">{formatDate(post.updatedAt)}</span>
+                </p>
+              </div>
+            </Link>
+          ))}
+        </AnimatedBackground>
+        {filteredPosts.length === 0 && (
+          <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+            선택한 태그에 해당하는 문서가 없습니다.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/wiki/wiki-list.tsx
+++ b/app/wiki/wiki-list.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { AnimatedBackground } from '@/components/ui/animated-background'
+import { formatWikiDate } from '@/lib/wiki-date'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 
@@ -15,14 +16,6 @@ export type WikiListItem = {
 type WikiListProps = {
   posts: WikiListItem[]
   tags: string[]
-}
-
-const formatDate = (value: string) => {
-  return new Date(value).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  })
 }
 
 export function WikiList({ posts, tags }: WikiListProps) {
@@ -41,6 +34,7 @@ export function WikiList({ posts, tags }: WikiListProps) {
       <div className="mb-4 flex flex-wrap gap-2">
         <button
           type="button"
+          aria-pressed={selectedTag === null}
           onClick={() => setSelectedTag(null)}
           className={`rounded-full border px-3 py-1 text-xs transition-colors ${
             selectedTag === null
@@ -54,6 +48,7 @@ export function WikiList({ posts, tags }: WikiListProps) {
           <button
             key={tag}
             type="button"
+            aria-pressed={selectedTag === tag}
             onClick={() => setSelectedTag((prevTag) => (prevTag === tag ? null : tag))}
             className={`rounded-full border px-3 py-1 text-xs transition-colors ${
               selectedTag === tag
@@ -96,7 +91,7 @@ export function WikiList({ posts, tags }: WikiListProps) {
                 </div>
                 <p className="mb-0! flex flex-col gap-1 text-zinc-500 dark:text-zinc-400">
                   {post.description && <span className="text-sm">{post.description}</span>}
-                  <span className="text-xs">{formatDate(post.updatedAt)}</span>
+                  <span className="text-xs">{formatWikiDate(post.updatedAt)}</span>
                 </p>
               </div>
             </Link>

--- a/content/wiki/nextjs-static-export.mdx
+++ b/content/wiki/nextjs-static-export.mdx
@@ -1,0 +1,16 @@
+---
+title: Next.js Static Export 운영 메모
+description: GitHub Pages 정적 배포 환경에서 App Router를 운영할 때 점검한 항목들
+tags:
+  - nextjs
+  - deployment
+aliases:
+  - next-export-checklist
+updatedAt: 2026-04-19
+---
+
+GitHub Pages 환경에서는 동적 런타임을 기대하지 않고, 빌드 시점 산출물 기준으로 페이지를 구성해야 한다.
+
+정적 라우트 설계 관점에서는 `generateStaticParams`를 미리 구현해두는 것이 핵심이다.
+
+상세한 콘텐츠 파이프라인 결정은 [[velite-wiki-pipeline]] 문서에 이어서 정리했다.

--- a/content/wiki/velite-wiki-pipeline.mdx
+++ b/content/wiki/velite-wiki-pipeline.mdx
@@ -1,0 +1,16 @@
+---
+title: Velite Wiki 파이프라인 노트
+description: 위키 문서 컬렉션과 렌더링 데이터 흐름을 기록한 문서
+tags:
+  - velite
+  - wiki
+aliases:
+  - content-pipeline
+updatedAt: 2026-04-19
+---
+
+`velite`에서 위키 문서를 하나의 컬렉션으로 다루면 slug, 태그, 본문을 일관된 타입으로 가져올 수 있다.
+
+문서 간 연결은 `[[wikilink]]` 형태로 작성하고, 링크 인덱싱 정보는 후속 작업에서 그래프 데이터로 확장한다.
+
+정적 배포 제약사항은 [[nextjs-static-export]] 문서를 참고한다.

--- a/lib/wiki-date.ts
+++ b/lib/wiki-date.ts
@@ -1,0 +1,10 @@
+const wikiDateFormatter = new Intl.DateTimeFormat('ko-KR', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  timeZone: 'Asia/Seoul',
+})
+
+export const formatWikiDate = (value: string) => {
+  return wikiDateFormatter.format(new Date(value))
+}

--- a/lib/wiki-posts.ts
+++ b/lib/wiki-posts.ts
@@ -7,7 +7,8 @@ export type WikiPost = Wiki & {
   slugAsParams: string
 }
 
-const toSlugAsParams = (slug: string) => slug.replace(/^wiki\//, '')
+const toSlugAsParams = (slug: string) =>
+  slug.startsWith(WIKI_PREFIX) ? slug.slice(WIKI_PREFIX.length) : slug
 
 export const getWikiPosts = () => {
   return wiki

--- a/lib/wiki-posts.ts
+++ b/lib/wiki-posts.ts
@@ -1,0 +1,34 @@
+import { wiki } from '#site/content'
+import type { Wiki } from '#site/content'
+
+const WIKI_PREFIX = 'wiki/'
+
+export type WikiPost = Wiki & {
+  slugAsParams: string
+}
+
+const toSlugAsParams = (slug: string) => slug.replace(/^wiki\//, '')
+
+export const getWikiPosts = () => {
+  return wiki
+    .filter((post) => post.slug.startsWith(WIKI_PREFIX))
+    .map((post) => ({
+      ...post,
+      slugAsParams: toSlugAsParams(post.slug),
+    }))
+    .sort((a, b) => {
+      return (
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      )
+    })
+}
+
+export const getWikiPost = (slug: string) => {
+  return getWikiPosts().find((post) => post.slugAsParams === slug)
+}
+
+export const getWikiTags = () => {
+  return [...new Set(getWikiPosts().flatMap((post) => post.tags))].sort((a, b) =>
+    a.localeCompare(b, 'ko-KR'),
+  )
+}

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -2,6 +2,25 @@ import remarkWikiLink from '@flowershow/remark-wiki-link'
 import { defineCollection, defineConfig, s } from 'velite'
 
 const wikiLinkRemarkPlugin = remarkWikiLink as any
+const WIKI_LINK_PATTERN = /\[\[([^[\]]+)\]\]/g
+
+const extractWikiLinks = (raw: string) => {
+  const sanitized = raw
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`\n]+`/g, '')
+  const links = new Set<string>()
+
+  for (const match of sanitized.matchAll(WIKI_LINK_PATTERN)) {
+    const [rawLink] = match[1].split('|')
+    const normalizedLink = rawLink.trim().replaceAll(' ', '-').toLowerCase()
+
+    if (normalizedLink) {
+      links.add(normalizedLink)
+    }
+  }
+
+  return [...links]
+}
 
 const baseContentSchema = s.object({
   title: s.string(),
@@ -49,7 +68,16 @@ const books = defineCollection({
 const wiki = defineCollection({
   name: 'Wiki',
   pattern: 'wiki/**/*.{md,mdx}',
-  schema: baseContentSchema,
+  schema: s.object({
+    title: s.string(),
+    description: s.string().optional(),
+    tags: s.array(s.string()).default([]),
+    aliases: s.array(s.string()).default([]),
+    updatedAt: s.isodate(),
+    slug: s.path(),
+    body: s.mdx(),
+    wikilinks: s.raw().transform((raw) => extractWikiLinks(raw ?? '')),
+  }),
 })
 
 export default defineConfig({


### PR DESCRIPTION
## 관련 이슈
- close #40
- tracking #47

## 작업 내용
- `velite.config.ts`의 `wiki` 컬렉션 스키마를 이슈 요구사항에 맞게 확장했습니다.
  - `title`, `description?`, `tags[]`, `aliases[]`, `updatedAt`, `slug`, `body`, `wikilinks` 필드 구성
  - `[[wikilink]]`를 추출하는 커스텀 파이프라인 추가 (`wikilinks`, 기본 빈 배열)
- `content/wiki`에 샘플 문서 2건을 추가하고 문서 간 `[[link]]` 상호 참조를 구성했습니다.
  - `nextjs-static-export.mdx`
  - `velite-wiki-pipeline.mdx`
- 위키 데이터 접근 유틸을 추가했습니다.
  - `lib/wiki-posts.ts` (`getWikiPosts`, `getWikiPost`, `getWikiTags`)
- 위키 목록 페이지를 구현했습니다.
  - `app/wiki/page.tsx`
  - 태그 토글 필터(클라이언트) + `/wiki/graph` 진입 링크(placeholder)
- 위키 상세 페이지를 구현했습니다.
  - `app/wiki/[slug]/page.tsx`
  - `generateStaticParams` 구현
  - 본문 렌더 + 상단 태그 칩 + 하단 backlinks 섹션(현재 빈 배열)
- `/wiki/graph` placeholder 페이지를 추가했습니다.

## 검증
- `pnpm typecheck`
- `pnpm build`
