### PR TITLE
[#43] 홈 페이지 갱신: Logs 제거 및 Books/Wiki 섹션 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,23 @@
 import HomeClient from '@/components/widget/home-client'
 import { getSortedBlogListItems } from '@/lib/blog'
-import { books, wiki } from '#site/content'
+import { getBooks } from '@/lib/books'
+import { getWikiPosts } from '@/lib/wiki-posts'
 
 export default function HomePage() {
   const blogPosts = getSortedBlogListItems()
-  const recentBooks = books.slice(0, 3).map((book) => ({
-    slug: book.slug,
-    title: book.title,
-    author: book.author,
-    readDate: book.readDate,
-  }))
+  const recentBooks = getBooks()
+    .slice(0, 3)
+    .map((book) => ({
+      slug: book.slug,
+      title: book.title,
+      author: book.author,
+      readDate: book.readDate,
+    }))
 
-  const recentWikiPosts = [...wiki]
-    .sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    )
+  const recentWikiPosts = getWikiPosts()
     .slice(0, 5)
     .map((post) => ({
-      slug: post.slug.replace(/^wiki\//, ''),
+      slug: post.slugAsParams,
       title: post.title,
       updatedAt: post.updatedAt,
     }))

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,33 @@
 import HomeClient from '@/components/widget/home-client'
 import { getSortedBlogListItems } from '@/lib/blog'
+import { books, wiki } from '#site/content'
 
 export default function HomePage() {
   const blogPosts = getSortedBlogListItems()
+  const recentBooks = books.slice(0, 3).map((book) => ({
+    slug: book.slug,
+    title: book.title,
+    author: book.author,
+    readDate: book.readDate,
+  }))
 
-  return <HomeClient blogPosts={blogPosts} />
+  const recentWikiPosts = [...wiki]
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    )
+    .slice(0, 5)
+    .map((post) => ({
+      slug: post.slug.replace(/^wiki\//, ''),
+      title: post.title,
+      updatedAt: post.updatedAt,
+    }))
+
+  return (
+    <HomeClient
+      blogPosts={blogPosts}
+      recentBooks={recentBooks}
+      recentWikiPosts={recentWikiPosts}
+    />
+  )
 }

--- a/components/widget/home-client.tsx
+++ b/components/widget/home-client.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/morphing-dialog'
 import { Spotlight } from '@/components/ui/spotlight'
 import type { BlogListItem } from '@/lib/blog'
+import { formatWikiDate } from '@/lib/wiki-date'
 import { motion } from 'motion/react'
 import Link from 'next/link'
 import { EMAIL, SOCIAL_LINKS, WORK_EXPERIENCE } from '../../constants/data'
@@ -73,8 +74,21 @@ function MagneticSocialLink({
 
 export default function HomeClient({
   blogPosts,
+  recentBooks,
+  recentWikiPosts,
 }: {
   blogPosts: BlogListItem[]
+  recentBooks: {
+    slug: string
+    title: string
+    author: string
+    readDate: string
+  }[]
+  recentWikiPosts: {
+    slug: string
+    title: string
+    updatedAt: string
+  }[]
 }) {
   return (
     <motion.main
@@ -293,6 +307,105 @@ export default function HomeClient({
                   <p className="flex flex-col gap-1 text-zinc-500 dark:text-zinc-400">
                     <span className="text-sm">{post.description}</span>
                     <span className="text-xs">{post.date}</span>
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </AnimatedBackground>
+        </div>
+      </motion.section>
+
+      <motion.section
+        variants={VARIANTS_SECTION}
+        transition={TRANSITION_SECTION}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-lg font-medium dark:text-zinc-100">Books</h3>
+          <Link
+            href="/books"
+            className="text-sm text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+          >
+            More {'>'}
+          </Link>
+        </div>
+        <div className="flex flex-col space-y-0">
+          <AnimatedBackground
+            enableHover
+            className="h-full w-full rounded-lg bg-zinc-100 dark:bg-zinc-900/80"
+            transition={{
+              type: 'spring',
+              bounce: 0,
+              duration: 0.2,
+            }}
+          >
+            {recentBooks.map((book) => {
+              const link = `/books/${book.slug}`
+              return (
+                <Link
+                  key={book.slug}
+                  className="-mx-3 rounded-xl px-3 py-3"
+                  href={link}
+                  data-id={book.slug}
+                >
+                  <div className="flex flex-col space-y-1">
+                    <h4 className="font-normal dark:text-zinc-100">
+                      {book.title}
+                    </h4>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                      {book.author} · {book.readDate}
+                    </p>
+                  </div>
+                </Link>
+              )
+            })}
+          </AnimatedBackground>
+        </div>
+      </motion.section>
+
+      <motion.section
+        variants={VARIANTS_SECTION}
+        transition={TRANSITION_SECTION}
+      >
+        <div className="mb-3 flex items-center justify-between gap-4">
+          <h3 className="text-lg font-medium dark:text-zinc-100">Wiki</h3>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/wiki/graph"
+              className="text-sm text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+            >
+              View graph →
+            </Link>
+            <Link
+              href="/wiki"
+              className="text-sm text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+            >
+              More {'>'}
+            </Link>
+          </div>
+        </div>
+        <div className="flex flex-col space-y-0">
+          <AnimatedBackground
+            enableHover
+            className="h-full w-full rounded-lg bg-zinc-100 dark:bg-zinc-900/80"
+            transition={{
+              type: 'spring',
+              bounce: 0,
+              duration: 0.2,
+            }}
+          >
+            {recentWikiPosts.map((post) => (
+              <Link
+                key={post.slug}
+                className="-mx-3 rounded-xl px-3 py-3"
+                href={`/wiki/${post.slug}`}
+                data-id={post.slug}
+              >
+                <div className="flex flex-col space-y-1">
+                  <h4 className="font-normal dark:text-zinc-100">
+                    {post.title}
+                  </h4>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                    {formatWikiDate(post.updatedAt)}
                   </p>
                 </div>
               </Link>


### PR DESCRIPTION
## 작업 개요
트래킹 이슈 #47 기준으로 홈 페이지에서 기존 Logs 영역을 제거하고, Books/Wiki 영역을 추가했습니다.

## 변경 내용
- `app/page.tsx`
- `getLogSeries` 호출 제거
- velite 컬렉션에서 홈 노출용 데이터 구성 후 `HomeClient`로 전달
  - `books.slice(0, 3)`
  - `wiki`를 `updatedAt` 내림차순 정렬 후 `slice(0, 5)`
- `components/widget/home-client.tsx`
- `logCategories` props/타입 및 Logs 섹션 제거
- Blog 아래에 Books 섹션 추가 (최근 3권: 제목/저자/날짜)
- 그 아래 Wiki 섹션 추가 (최신 5건)
- Wiki 섹션에 `View graph →` 링크(`/wiki/graph`) 추가

## 검증
- `pnpm exec eslint app/page.tsx components/widget/home-client.tsx`
- `pnpm build`

## 참고
- Tracking: #47
- Closes: #43
