### PR TITLE
[wiki-revamp] #41 Wikilink 파이프라인 + 그래프 데이터 구현

### DIFF
--- a/app/wiki/[slug]/page.tsx
+++ b/app/wiki/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { MDXContent } from '@/components/mdx-content'
 import { formatWikiDate } from '@/lib/wiki-date'
+import { getBacklinks } from '@/lib/wiki-graph'
 import { getWikiPost, getWikiPosts } from '@/lib/wiki-posts'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
@@ -24,7 +25,7 @@ export default async function WikiDetailPage({ params }: WikiDetailPageProps) {
     notFound()
   }
 
-  const backlinks: string[] = []
+  const backlinks = getBacklinks(post.slugAsParams)
 
   return (
     <main className="mt-24 pb-20">
@@ -62,6 +63,25 @@ export default async function WikiDetailPage({ params }: WikiDetailPageProps) {
           <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
             연결된 역링크가 아직 없습니다.
           </p>
+        )}
+        {backlinks.length > 0 && (
+          <ul className="mt-3 space-y-2">
+            {backlinks.map((backlink) => (
+              <li key={`${post.slugAsParams}-backlink-${backlink.slugAsParams}`}>
+                <Link
+                  href={`/wiki/${backlink.slugAsParams}`}
+                  className="text-sm text-zinc-700 underline-offset-2 transition-colors hover:text-zinc-900 hover:underline dark:text-zinc-300 dark:hover:text-zinc-100"
+                >
+                  {backlink.title}
+                </Link>
+                {backlink.description && (
+                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                    {backlink.description}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
         )}
       </section>
     </main>

--- a/lib/wiki-graph.ts
+++ b/lib/wiki-graph.ts
@@ -1,0 +1,69 @@
+import { getWikiPosts, type WikiPost } from '@/lib/wiki-posts'
+
+export type WikiGraphNode = {
+  id: string
+  label: string
+  kind: 'wiki' | 'ghost'
+}
+
+export type WikiGraphLink = {
+  source: string
+  target: string
+}
+
+export type WikiGraph = {
+  nodes: WikiGraphNode[]
+  links: WikiGraphLink[]
+}
+
+const normalizeWikiSlug = (slug: string) =>
+  slug.trim().replaceAll(' ', '-').toLowerCase()
+
+export const getGraph = (): WikiGraph => {
+  const posts = getWikiPosts()
+  const nodes = new Map<string, WikiGraphNode>()
+  const links = new Map<string, WikiGraphLink>()
+
+  for (const post of posts) {
+    nodes.set(post.slugAsParams, {
+      id: post.slugAsParams,
+      label: post.title,
+      kind: 'wiki',
+    })
+  }
+
+  for (const post of posts) {
+    for (const targetSlug of post.wikilinks) {
+      const normalizedTargetSlug = normalizeWikiSlug(targetSlug)
+      if (!normalizedTargetSlug) {
+        continue
+      }
+
+      if (!nodes.has(normalizedTargetSlug)) {
+        nodes.set(normalizedTargetSlug, {
+          id: normalizedTargetSlug,
+          label: normalizedTargetSlug,
+          kind: 'ghost',
+        })
+      }
+
+      const key = `${post.slugAsParams}->${normalizedTargetSlug}`
+      links.set(key, {
+        source: post.slugAsParams,
+        target: normalizedTargetSlug,
+      })
+    }
+  }
+
+  return {
+    nodes: [...nodes.values()].sort((a, b) => a.id.localeCompare(b.id, 'ko-KR')),
+    links: [...links.values()].sort((a, b) =>
+      `${a.source}->${a.target}`.localeCompare(`${b.source}->${b.target}`, 'ko-KR'),
+    ),
+  }
+}
+
+export const getBacklinks = (slug: string): WikiPost[] => {
+  const normalizedSlug = normalizeWikiSlug(slug)
+  return getWikiPosts().filter((post) => post.wikilinks.includes(normalizedSlug))
+}

--- a/lib/wiki-graph.ts
+++ b/lib/wiki-graph.ts
@@ -1,4 +1,5 @@
 import { getWikiPosts, type WikiPost } from '@/lib/wiki-posts'
+import { normalizeWikiSlug } from '@/lib/wiki-slug'
 
 export type WikiGraphNode = {
   id: string
@@ -15,9 +16,6 @@ export type WikiGraph = {
   nodes: WikiGraphNode[]
   links: WikiGraphLink[]
 }
-
-const normalizeWikiSlug = (slug: string) =>
-  slug.trim().replaceAll(' ', '-').toLowerCase()
 
 export const getGraph = (): WikiGraph => {
   const posts = getWikiPosts()

--- a/lib/wiki-slug.ts
+++ b/lib/wiki-slug.ts
@@ -1,0 +1,2 @@
+export const normalizeWikiSlug = (slug: string) =>
+  slug.trim().replaceAll(' ', '-').toLowerCase()

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -1,4 +1,5 @@
 import { defineCollection, defineConfig, s } from 'velite'
+import { normalizeWikiSlug } from './lib/wiki-slug'
 
 type RemarkNode = {
   type: string
@@ -38,9 +39,6 @@ const NON_TRAVERSABLE_NODES = new Set([
   'yaml',
   'html',
 ])
-
-const normalizeWikiSlug = (slug: string) =>
-  slug.trim().replaceAll(' ', '-').toLowerCase()
 
 const extractWikiLinksFromRaw = (raw: string): string[] => {
   const sanitized = raw

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -1,26 +1,205 @@
-import remarkWikiLink from '@flowershow/remark-wiki-link'
 import { defineCollection, defineConfig, s } from 'velite'
 
-const wikiLinkRemarkPlugin = remarkWikiLink as any
-const WIKI_LINK_PATTERN = /\[\[([^[\]]+)\]\]/g
+type RemarkNode = {
+  type: string
+  value?: string
+  url?: string
+  title?: string | null
+  children?: RemarkNode[]
+}
 
-const extractWikiLinks = (raw: string) => {
+type RemarkFile = {
+  data?: {
+    data?: Record<string, unknown>
+    [key: string]: unknown
+  }
+}
+
+type VeliteTransformContext = {
+  meta?: {
+    content?: string
+    mdast?: RemarkNode
+    data?: {
+      data?: {
+        wikilinks?: unknown
+      }
+      wikilinks?: unknown
+    }
+  }
+}
+
+const WIKI_LINK_PATTERN = /\[\[([^[\]]+)\]\]/g
+const NON_TRAVERSABLE_NODES = new Set([
+  'code',
+  'inlineCode',
+  'link',
+  'linkReference',
+  'definition',
+  'yaml',
+  'html',
+])
+
+const normalizeWikiSlug = (slug: string) =>
+  slug.trim().replaceAll(' ', '-').toLowerCase()
+
+const extractWikiLinksFromRaw = (raw: string): string[] => {
   const sanitized = raw
     .replace(/```[\s\S]*?```/g, '')
     .replace(/`[^`\n]+`/g, '')
-  const links = new Set<string>()
+  const wikilinks = new Set<string>()
 
   for (const match of sanitized.matchAll(WIKI_LINK_PATTERN)) {
-    const [rawLink] = match[1].split('|')
-    const normalizedLink = rawLink.trim().replaceAll(' ', '-').toLowerCase()
-
-    if (normalizedLink) {
-      links.add(normalizedLink)
+    const [target] = match[1].split('|')
+    const normalizedTarget = normalizeWikiSlug(target ?? '')
+    if (normalizedTarget) {
+      wikilinks.add(normalizedTarget)
     }
   }
 
-  return [...links]
+  return [...wikilinks]
 }
+
+const extractWikiLinksFromText = (value: string, wikilinks: Set<string>) => {
+  for (const match of value.matchAll(WIKI_LINK_PATTERN)) {
+    const [target] = match[1].split('|')
+    const normalizedTarget = normalizeWikiSlug(target ?? '')
+    if (normalizedTarget) {
+      wikilinks.add(normalizedTarget)
+    }
+  }
+}
+
+const extractWikiLinksFromMdast = (node: RemarkNode | undefined): string[] => {
+  if (!node) {
+    return []
+  }
+
+  const wikilinks = new Set<string>()
+
+  const visit = (current: RemarkNode) => {
+    if (NON_TRAVERSABLE_NODES.has(current.type)) {
+      return
+    }
+
+    if (isTextNode(current)) {
+      extractWikiLinksFromText(current.value, wikilinks)
+      return
+    }
+
+    if (!isParentNode(current)) {
+      return
+    }
+
+    for (const child of current.children) {
+      visit(child)
+    }
+  }
+
+  visit(node)
+  return [...wikilinks]
+}
+
+const sanitizeWikiLinks = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => normalizeWikiSlug(item))
+    .filter(Boolean)
+}
+
+const createTextNode = (value: string): RemarkNode => ({
+  type: 'text',
+  value,
+})
+
+const createWikiLinkNode = (slug: string, label: string): RemarkNode => ({
+  type: 'link',
+  url: `/wiki/${slug}`,
+  title: null,
+  children: [createTextNode(label)],
+})
+
+const splitWikiLinks = (value: string, wikilinks: Set<string>): RemarkNode[] => {
+  const chunks: RemarkNode[] = []
+  let startIndex = 0
+
+  for (const match of value.matchAll(WIKI_LINK_PATTERN)) {
+    const [fullMatch, inner] = match
+    const matchIndex = match.index ?? 0
+
+    if (matchIndex > startIndex) {
+      chunks.push(createTextNode(value.slice(startIndex, matchIndex)))
+    }
+
+    const [rawTarget, rawAlias] = inner.split('|')
+    const target = normalizeWikiSlug(rawTarget ?? '')
+    const label = (rawAlias ?? rawTarget ?? '').trim()
+
+    if (!target) {
+      chunks.push(createTextNode(fullMatch))
+    } else {
+      wikilinks.add(target)
+      chunks.push(createWikiLinkNode(target, label || target))
+    }
+
+    startIndex = matchIndex + fullMatch.length
+  }
+
+  if (startIndex < value.length) {
+    chunks.push(createTextNode(value.slice(startIndex)))
+  }
+
+  return chunks.length > 0 ? chunks : [createTextNode(value)]
+}
+
+const isParentNode = (
+  node: RemarkNode,
+): node is RemarkNode & { children: RemarkNode[] } => Array.isArray(node.children)
+
+const isTextNode = (
+  node: RemarkNode,
+): node is RemarkNode & { value: string } =>
+  node.type === 'text' && typeof node.value === 'string'
+
+const transformWikiLinks = (node: RemarkNode, wikilinks: Set<string>) => {
+  if (!isParentNode(node) || NON_TRAVERSABLE_NODES.has(node.type)) {
+    return
+  }
+
+  const nextChildren: RemarkNode[] = []
+
+  for (const child of node.children) {
+    if (isTextNode(child)) {
+      nextChildren.push(...splitWikiLinks(child.value, wikilinks))
+      continue
+    }
+
+    transformWikiLinks(child, wikilinks)
+    nextChildren.push(child)
+  }
+
+  node.children = nextChildren
+}
+
+const wikiLinkRemarkPlugin = () => {
+  return (tree: RemarkNode, file: RemarkFile) => {
+    const wikilinks = new Set<string>()
+    transformWikiLinks(tree, wikilinks)
+    const collectedWikiLinks = [...wikilinks]
+
+    const fileData = file.data ?? {}
+    fileData.wikilinks = collectedWikiLinks
+    if (fileData.data && typeof fileData.data === 'object') {
+      fileData.data.wikilinks = collectedWikiLinks
+    }
+    file.data = fileData
+  }
+}
+
+const wikiLinkRemarkPluginPluggable = wikiLinkRemarkPlugin as any
 
 const baseContentSchema = s.object({
   title: s.string(),
@@ -76,7 +255,23 @@ const wiki = defineCollection({
     updatedAt: s.isodate(),
     slug: s.path(),
     body: s.mdx(),
-    wikilinks: s.raw().transform((raw) => extractWikiLinks(raw ?? '')),
+    wikilinks: s.raw().transform((raw, ctx) => {
+      const meta = (ctx as VeliteTransformContext).meta
+      const linksFromMeta = sanitizeWikiLinks(
+        meta?.data?.data?.wikilinks ?? meta?.data?.wikilinks,
+      )
+
+      if (linksFromMeta.length > 0) {
+        return linksFromMeta
+      }
+
+      const linksFromMdast = extractWikiLinksFromMdast(meta?.mdast)
+      if (linksFromMdast.length > 0) {
+        return linksFromMdast
+      }
+
+      return extractWikiLinksFromRaw(raw ?? meta?.content ?? '')
+    }),
   }),
 })
 
@@ -88,9 +283,9 @@ export default defineConfig({
     wiki,
   },
   markdown: {
-    remarkPlugins: [wikiLinkRemarkPlugin],
+    remarkPlugins: [wikiLinkRemarkPluginPluggable],
   },
   mdx: {
-    remarkPlugins: [wikiLinkRemarkPlugin],
+    remarkPlugins: [wikiLinkRemarkPluginPluggable],
   },
 })


### PR DESCRIPTION
## 관련 이슈
- Tracking: #47
- 작업 이슈: #41

## 변경 내용
- `velite.config.ts`
  - `[[slug]]`, `[[slug|별칭]]`를 `/wiki/{slug}` 링크로 변환하는 custom remark wikilink 파이프라인 추가
  - wikilink 타겟 slug 수집 로직 추가 및 `wiki.wikilinks` 필드에 연결
  - 코드/인라인 코드 영역 제외 처리로 오탐 링크 수집 방지
- `lib/wiki-graph.ts`
  - `getGraph()` 구현: `{ nodes, links }` 생성, 미해결 타겟은 `ghost` 노드로 포함
  - `getBacklinks(slug)` 구현: 특정 문서를 참조하는 역링크 문서 목록 반환
- `app/wiki/[slug]/page.tsx`
  - backlinks 섹션을 실제 데이터(`getBacklinks`)와 연결
  - 역링크가 있을 때 문서 제목/설명을 리스트로 렌더링

## 검증
- `pnpm build`
- `pnpm typecheck`

## 메모
- 현재 샘플 wiki 문서 기준으로 양방향 링크 및 backlinks 렌더링이 정상 동작함을 `out/wiki/*.html`, `.velite/wiki.json`에서 확인했습니다.

Closes #41
