### PR TITLE
[#42] /wiki/graph 풀스크린 그래프 뷰 구현

### DIFF
--- a/app/wiki/graph/page.tsx
+++ b/app/wiki/graph/page.tsx
@@ -1,18 +1,20 @@
+import { WikiGraphCanvas } from '@/components/widget/wiki-graph-canvas'
+import { getGraph } from '@/lib/wiki-graph'
+
 export const metadata = {
   title: 'Wiki Graph',
-  description: 'Wiki 그래프 뷰 플레이스홀더 페이지',
+  description: 'Wiki 문서 간 연결 구조를 인터랙티브 그래프로 탐색할 수 있습니다.',
   alternates: {
     canonical: '/wiki/graph',
   },
 }
 
-export default function WikiGraphPlaceholderPage() {
+export default function WikiGraphPage() {
+  const graph = getGraph()
+
   return (
-    <main className="mt-24 pb-20">
-      <h1 className="text-xl font-semibold">Wiki Graph</h1>
-      <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-        그래프 뷰는 후속 이슈에서 구현 예정입니다.
-      </p>
+    <main className="mt-2 pb-0">
+      <WikiGraphCanvas graph={graph} />
     </main>
   )
 }

--- a/app/wiki/graph/page.tsx
+++ b/app/wiki/graph/page.tsx
@@ -14,6 +14,7 @@ export default function WikiGraphPage() {
 
   return (
     <main className="mt-2 pb-0">
+      <h1 className="sr-only">Wiki Graph</h1>
       <WikiGraphCanvas graph={graph} />
     </main>
   )

--- a/app/wiki/page.tsx
+++ b/app/wiki/page.tsx
@@ -33,7 +33,7 @@ export default function WikiIndexPage() {
           href="/wiki/graph"
           className="shrink-0 rounded-full border border-zinc-300 px-3 py-1.5 text-xs text-zinc-600 transition-colors hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500"
         >
-          Graph 보기 (준비 중)
+          Graph 보기
         </Link>
       </div>
       <WikiList posts={posts} tags={tags} />

--- a/components/widget/wiki-graph-canvas.tsx
+++ b/components/widget/wiki-graph-canvas.tsx
@@ -1,0 +1,570 @@
+'use client'
+
+import type { WikiGraph, WikiGraphNode } from '@/lib/wiki-graph'
+import dynamic from 'next/dynamic'
+import { useRouter } from 'next/navigation'
+import { useTheme } from 'next-themes'
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), { ssr: false })
+
+const LIGHT_TAG_COLORS = [
+  '#0d9488',
+  '#0f766e',
+  '#2563eb',
+  '#9333ea',
+  '#c2410c',
+  '#059669',
+  '#be123c',
+  '#7c3aed',
+]
+
+const DARK_TAG_COLORS = [
+  '#2dd4bf',
+  '#38bdf8',
+  '#60a5fa',
+  '#c084fc',
+  '#fb923c',
+  '#34d399',
+  '#fb7185',
+  '#a78bfa',
+]
+
+type WikiGraphCanvasProps = {
+  graph: WikiGraph
+}
+
+type GraphNode = WikiGraphNode & {
+  x?: number
+  y?: number
+  vx?: number
+  vy?: number
+  fx?: number
+  fy?: number
+}
+
+type GraphLink = {
+  source: string | GraphNode
+  target: string | GraphNode
+}
+
+const getNodeId = (node: unknown): string => {
+  if (!node) {
+    return ''
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (typeof node === 'object' && node !== null && 'id' in node) {
+    return String((node as { id?: string | number }).id ?? '')
+  }
+
+  return ''
+}
+
+export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
+  const router = useRouter()
+  const { resolvedTheme } = useTheme()
+
+  const isDark = resolvedTheme === 'dark'
+  const graphRef = useRef<any>(undefined)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const [canvasWidth, setCanvasWidth] = useState(0)
+  const [canvasHeight, setCanvasHeight] = useState(0)
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null)
+  const [highlightedNodeIds, setHighlightedNodeIds] = useState<Set<string>>(new Set())
+  const [highlightedLinkIds, setHighlightedLinkIds] = useState<Set<string>>(new Set())
+  const [searchKeyword, setSearchKeyword] = useState('')
+  const [searchMessage, setSearchMessage] = useState('')
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null)
+
+  const nodes = useMemo<GraphNode[]>(() => graph.nodes.map((node) => ({ ...node })), [graph.nodes])
+  const links = useMemo<GraphLink[]>(() => graph.links.map((link) => ({ ...link })), [graph.links])
+
+  const tags = useMemo(() => {
+    return [...new Set(nodes.flatMap((node) => node.tags))].sort((a, b) =>
+      a.localeCompare(b, 'ko-KR'),
+    )
+  }, [nodes])
+
+  const [enabledTags, setEnabledTags] = useState<string[]>(tags)
+
+  useEffect(() => {
+    setEnabledTags(tags)
+  }, [tags])
+
+  useEffect(() => {
+    const updateCanvasSize = () => {
+      if (!containerRef.current) {
+        return
+      }
+
+      const rect = containerRef.current.getBoundingClientRect()
+      setCanvasWidth(rect.width)
+      setCanvasHeight(Math.max(360, window.innerHeight - rect.top))
+    }
+
+    updateCanvasSize()
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateCanvasSize()
+    })
+
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current)
+    }
+
+    window.addEventListener('resize', updateCanvasSize)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', updateCanvasSize)
+    }
+  }, [])
+
+  const enabledTagSet = useMemo(() => new Set(enabledTags), [enabledTags])
+
+  const nodeById = useMemo(() => {
+    const byId = new Map<string, GraphNode>()
+
+    for (const node of nodes) {
+      byId.set(node.id, node)
+    }
+
+    return byId
+  }, [nodes])
+
+  const { neighborsByNodeId, linksByNodeId } = useMemo(() => {
+    const neighbors = new Map<string, Set<string>>()
+    const linksMap = new Map<string, Set<string>>()
+
+    for (const link of links) {
+      const sourceId = getNodeId(link.source)
+      const targetId = getNodeId(link.target)
+      const linkId = `${sourceId}->${targetId}`
+
+      if (!neighbors.has(sourceId)) {
+        neighbors.set(sourceId, new Set())
+      }
+      if (!neighbors.has(targetId)) {
+        neighbors.set(targetId, new Set())
+      }
+      neighbors.get(sourceId)?.add(targetId)
+      neighbors.get(targetId)?.add(sourceId)
+
+      if (!linksMap.has(sourceId)) {
+        linksMap.set(sourceId, new Set())
+      }
+      if (!linksMap.has(targetId)) {
+        linksMap.set(targetId, new Set())
+      }
+      linksMap.get(sourceId)?.add(linkId)
+      linksMap.get(targetId)?.add(linkId)
+    }
+
+    return {
+      neighborsByNodeId: neighbors,
+      linksByNodeId: linksMap,
+    }
+  }, [links])
+
+  const visibleNodeIds = useMemo(() => {
+    const visibleIds = new Set<string>()
+
+    for (const node of nodes) {
+      if (node.kind === 'ghost') {
+        continue
+      }
+
+      if (node.tags.some((tag) => enabledTagSet.has(tag))) {
+        visibleIds.add(node.id)
+      }
+    }
+
+    for (const link of links) {
+      const sourceId = getNodeId(link.source)
+      const targetId = getNodeId(link.target)
+
+      if (visibleIds.has(sourceId)) {
+        const targetNode = nodeById.get(targetId)
+        if (targetNode?.kind === 'ghost') {
+          visibleIds.add(targetId)
+        }
+      }
+
+      if (visibleIds.has(targetId)) {
+        const sourceNode = nodeById.get(sourceId)
+        if (sourceNode?.kind === 'ghost') {
+          visibleIds.add(sourceId)
+        }
+      }
+    }
+
+    return visibleIds
+  }, [enabledTagSet, links, nodeById, nodes])
+
+  const tagColorMap = useMemo(() => {
+    const palette = isDark ? DARK_TAG_COLORS : LIGHT_TAG_COLORS
+
+    return new Map(tags.map((tag, index) => [tag, palette[index % palette.length]]))
+  }, [isDark, tags])
+
+  const graphData = useMemo(
+    () => ({
+      nodes,
+      links,
+    }),
+    [links, nodes],
+  )
+
+  const nodeLabel = useCallback((node: any) => {
+    const item = node as GraphNode
+    if (item.kind === 'ghost') {
+      return `${item.slug} (미작성)`
+    }
+
+    const tagsText = item.tags.map((tag) => `#${tag}`).join(', ')
+    return `${item.label}\n/${item.slug}${tagsText ? `\n${tagsText}` : ''}`
+  }, [])
+
+  const getNodeFillColor = useCallback(
+    (node: GraphNode) => {
+      if (node.kind === 'ghost') {
+        return isDark ? '#52525b' : '#a1a1aa'
+      }
+
+      const matchingTag = node.tags.find((tag) => enabledTagSet.has(tag)) ?? node.tags[0]
+      return matchingTag ? (tagColorMap.get(matchingTag) ?? (isDark ? '#60a5fa' : '#2563eb')) : '#2563eb'
+    },
+    [enabledTagSet, isDark, tagColorMap],
+  )
+
+  const handleNodeHover = useCallback(
+    (node: any | null) => {
+      if (!node || !node.id) {
+        setHoveredNodeId(null)
+        setHighlightedNodeIds(new Set())
+        setHighlightedLinkIds(new Set())
+        return
+      }
+
+      const id = String(node.id)
+      setHoveredNodeId(id)
+
+      const neighborIds = neighborsByNodeId.get(id) ?? new Set<string>()
+      const nodeSet = new Set<string>([id, ...neighborIds])
+      const linkSet = new Set<string>(linksByNodeId.get(id) ?? new Set<string>())
+
+      setHighlightedNodeIds(nodeSet)
+      setHighlightedLinkIds(linkSet)
+    },
+    [linksByNodeId, neighborsByNodeId],
+  )
+
+  const focusNodeById = useCallback(
+    (targetNodeId: string) => {
+      let attempt = 0
+
+      const tryFocus = () => {
+        attempt += 1
+
+        const targetNode = nodeById.get(targetNodeId)
+        const graphApi = graphRef.current
+
+        if (!targetNode || !graphApi) {
+          return
+        }
+
+        if (typeof targetNode.x === 'number' && typeof targetNode.y === 'number') {
+          graphApi.centerAt(targetNode.x, targetNode.y, 700)
+          graphApi.zoom(3.5, 700)
+          return
+        }
+
+        if (attempt < 20) {
+          window.setTimeout(tryFocus, 80)
+        }
+      }
+
+      tryFocus()
+    },
+    [nodeById],
+  )
+
+  const handleSearch = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      const keyword = searchKeyword.trim().toLowerCase()
+      if (!keyword) {
+        setSearchMessage('')
+        return
+      }
+
+      const targetNode = nodes.find((node) => {
+        if (node.kind !== 'wiki') {
+          return false
+        }
+
+        return (
+          node.slug.toLowerCase().includes(keyword) || node.label.toLowerCase().includes(keyword)
+        )
+      })
+
+      if (!targetNode) {
+        setSearchMessage('일치하는 wiki 문서를 찾지 못했습니다.')
+        return
+      }
+
+      if (!visibleNodeIds.has(targetNode.id)) {
+        setEnabledTags((prev) => [...new Set([...prev, ...targetNode.tags])])
+      }
+
+      setFocusedNodeId(targetNode.id)
+      focusNodeById(targetNode.id)
+      setSearchMessage(`"${targetNode.label}" 노드로 이동했습니다.`)
+    },
+    [focusNodeById, nodes, searchKeyword, visibleNodeIds],
+  )
+
+  const nodeVisibility = useCallback(
+    (node: any) => {
+      return visibleNodeIds.has(String(node.id))
+    },
+    [visibleNodeIds],
+  )
+
+  const linkVisibility = useCallback(
+    (link: any) => {
+      const sourceId = getNodeId(link.source)
+      const targetId = getNodeId(link.target)
+
+      return visibleNodeIds.has(sourceId) && visibleNodeIds.has(targetId)
+    },
+    [visibleNodeIds],
+  )
+
+  const nodeCanvasObject = useCallback(
+    (node: any, context: CanvasRenderingContext2D, globalScale: number) => {
+      const item = node as GraphNode
+      const nodeId = String(item.id)
+
+      const isHighlighted =
+        hoveredNodeId === null || highlightedNodeIds.size === 0 ? true : highlightedNodeIds.has(nodeId)
+      const isFocused = focusedNodeId === nodeId
+
+      const radius = item.kind === 'ghost' ? 3.5 : 5.5
+      const opacity = isHighlighted ? 1 : 0.16
+      const fillColor = getNodeFillColor(item)
+
+      context.save()
+      context.beginPath()
+      context.arc(item.x ?? 0, item.y ?? 0, radius, 0, 2 * Math.PI)
+      context.fillStyle = fillColor
+      context.globalAlpha = opacity
+      context.fill()
+      context.closePath()
+
+      if (isFocused) {
+        context.beginPath()
+        context.arc(item.x ?? 0, item.y ?? 0, radius + 3, 0, 2 * Math.PI)
+        context.strokeStyle = isDark ? '#f8fafc' : '#0f172a'
+        context.lineWidth = 1.6
+        context.stroke()
+        context.closePath()
+      }
+
+      const showLabel = isFocused || nodeId === hoveredNodeId || globalScale > 2.2
+      if (showLabel) {
+        const fontSize = Math.max(11, 14 / globalScale)
+        const text = item.kind === 'ghost' ? item.slug : item.label
+        const textX = (item.x ?? 0) + radius + 3
+        const textY = item.y ?? 0
+
+        context.font = `${fontSize}px var(--font-pretendard)`
+        context.textAlign = 'left'
+        context.textBaseline = 'middle'
+
+        const textWidth = context.measureText(text).width
+        context.fillStyle = isDark ? 'rgba(9, 9, 11, 0.82)' : 'rgba(255, 255, 255, 0.82)'
+        context.fillRect(textX - 2, textY - fontSize * 0.65, textWidth + 4, fontSize * 1.3)
+
+        context.fillStyle = isDark ? '#f4f4f5' : '#18181b'
+        context.globalAlpha = opacity
+        context.fillText(text, textX, textY)
+      }
+
+      context.restore()
+    },
+    [focusedNodeId, getNodeFillColor, highlightedNodeIds, hoveredNodeId, isDark],
+  )
+
+  const linkColor = useCallback(
+    (link: any) => {
+      const sourceId = getNodeId(link.source)
+      const targetId = getNodeId(link.target)
+      const linkId = `${sourceId}->${targetId}`
+      const isHighlighted =
+        hoveredNodeId === null || highlightedLinkIds.size === 0 ? true : highlightedLinkIds.has(linkId)
+
+      if (!isHighlighted) {
+        return isDark ? 'rgba(82, 82, 91, 0.18)' : 'rgba(113, 113, 122, 0.18)'
+      }
+
+      return isDark ? 'rgba(212, 212, 216, 0.6)' : 'rgba(63, 63, 70, 0.45)'
+    },
+    [highlightedLinkIds, hoveredNodeId, isDark],
+  )
+
+  const linkWidth = useCallback(
+    (link: any) => {
+      const sourceId = getNodeId(link.source)
+      const targetId = getNodeId(link.target)
+      const linkId = `${sourceId}->${targetId}`
+
+      if (hoveredNodeId === null || highlightedLinkIds.size === 0) {
+        return 1
+      }
+
+      return highlightedLinkIds.has(linkId) ? 2 : 0.6
+    },
+    [highlightedLinkIds, hoveredNodeId],
+  )
+
+  const backgroundColor = isDark ? '#09090b' : '#fafafa'
+
+  return (
+    <div ref={containerRef} className="relative -mx-4">
+      <div
+        className="relative w-full border-y border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950"
+        style={{ height: canvasHeight > 0 ? `${canvasHeight}px` : 'calc(100vh - 10rem)' }}
+      >
+        <form
+          onSubmit={handleSearch}
+          className="absolute top-4 left-1/2 z-10 flex w-[min(92vw,28rem)] -translate-x-1/2 items-center gap-2 rounded-full border border-zinc-300 bg-white/90 p-2 backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/85"
+        >
+          <input
+            type="search"
+            value={searchKeyword}
+            onChange={(event) => setSearchKeyword(event.target.value)}
+            placeholder="slug 또는 title 검색"
+            className="w-full bg-transparent px-2 text-sm text-zinc-900 outline-none placeholder:text-zinc-400 dark:text-zinc-100"
+            aria-label="Wiki graph 검색"
+          />
+          <button
+            type="submit"
+            className="rounded-full bg-zinc-900 px-3 py-1 text-xs text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-200 dark:text-zinc-900 dark:hover:bg-zinc-300"
+          >
+            이동
+          </button>
+        </form>
+
+        <aside className="absolute top-4 left-4 z-10 max-h-[min(70vh,34rem)] w-64 overflow-auto rounded-2xl border border-zinc-300 bg-white/92 p-3 backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/88">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+              Tag Filter
+            </h2>
+            <div className="flex items-center gap-1 text-[10px]">
+              <button
+                type="button"
+                onClick={() => setEnabledTags(tags)}
+                className="rounded border border-zinc-300 px-1.5 py-0.5 text-zinc-600 hover:border-zinc-500 dark:border-zinc-700 dark:text-zinc-300"
+              >
+                전체
+              </button>
+              <button
+                type="button"
+                onClick={() => setEnabledTags([])}
+                className="rounded border border-zinc-300 px-1.5 py-0.5 text-zinc-600 hover:border-zinc-500 dark:border-zinc-700 dark:text-zinc-300"
+              >
+                해제
+              </button>
+            </div>
+          </div>
+
+          <ul className="space-y-1">
+            {tags.map((tag) => {
+              const checked = enabledTagSet.has(tag)
+              const color = tagColorMap.get(tag) ?? '#2563eb'
+
+              return (
+                <li key={tag}>
+                  <label className="flex cursor-pointer items-center gap-2 rounded px-1 py-1 text-xs text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(event) => {
+                        const nextChecked = event.target.checked
+
+                        setEnabledTags((prev) => {
+                          if (nextChecked) {
+                            return [...new Set([...prev, tag])]
+                          }
+
+                          return prev.filter((item) => item !== tag)
+                        })
+                      }}
+                      className="h-3.5 w-3.5 rounded border-zinc-300 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
+                    />
+                    <span
+                      className="inline-block h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: color }}
+                      aria-hidden={true}
+                    />
+                    <span>#{tag}</span>
+                  </label>
+                </li>
+              )
+            })}
+          </ul>
+        </aside>
+
+        {canvasWidth > 0 && canvasHeight > 0 && (
+          <ForceGraph2D
+            ref={graphRef}
+            graphData={graphData}
+            width={canvasWidth}
+            height={canvasHeight}
+            nodeId="id"
+            nodeLabel={nodeLabel}
+            nodeCanvasObject={nodeCanvasObject}
+            nodeVisibility={nodeVisibility}
+            linkVisibility={linkVisibility}
+            linkColor={linkColor}
+            linkWidth={linkWidth}
+            backgroundColor={backgroundColor}
+            cooldownTicks={120}
+            d3VelocityDecay={0.22}
+            onNodeHover={handleNodeHover}
+            onNodeClick={(node) => {
+              const item = node as GraphNode
+              if (item.kind === 'wiki') {
+                router.push(`/wiki/${item.slug}`)
+              }
+            }}
+            onBackgroundClick={() => {
+              setFocusedNodeId(null)
+              setSearchMessage('')
+            }}
+          />
+        )}
+
+        {searchMessage && (
+          <div className="absolute right-4 bottom-4 z-10 rounded-lg border border-zinc-300 bg-white/95 px-3 py-2 text-xs text-zinc-700 shadow-sm dark:border-zinc-700 dark:bg-zinc-900/95 dark:text-zinc-200">
+            {searchMessage}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/widget/wiki-graph-canvas.tsx
+++ b/components/widget/wiki-graph-canvas.tsx
@@ -186,6 +186,11 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
         continue
       }
 
+      if (node.tags.length === 0) {
+        visibleIds.add(node.id)
+        continue
+      }
+
       if (node.tags.some((tag) => enabledTagSet.has(tag))) {
         visibleIds.add(node.id)
       }
@@ -244,7 +249,9 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
       }
 
       const matchingTag = node.tags.find((tag) => enabledTagSet.has(tag)) ?? node.tags[0]
-      return matchingTag ? (tagColorMap.get(matchingTag) ?? (isDark ? '#60a5fa' : '#2563eb')) : '#2563eb'
+      const fallbackColor = isDark ? '#60a5fa' : '#2563eb'
+
+      return matchingTag ? (tagColorMap.get(matchingTag) ?? fallbackColor) : fallbackColor
     },
     [enabledTagSet, isDark, tagColorMap],
   )

--- a/lib/wiki-graph.ts
+++ b/lib/wiki-graph.ts
@@ -19,14 +19,18 @@ export type WikiGraph = {
   links: WikiGraphLink[]
 }
 
+const getCanonicalSlug = (slug: string) => normalizeWikiSlug(slug) || slug
+
 export const getGraph = (): WikiGraph => {
   const posts = getWikiPosts()
   const nodes = new Map<string, WikiGraphNode>()
   const links = new Map<string, WikiGraphLink>()
 
   for (const post of posts) {
-    nodes.set(post.slugAsParams, {
-      id: post.slugAsParams,
+    const canonicalSlug = getCanonicalSlug(post.slugAsParams)
+
+    nodes.set(canonicalSlug, {
+      id: canonicalSlug,
       label: post.title,
       slug: post.slugAsParams,
       tags: post.tags,
@@ -35,6 +39,8 @@ export const getGraph = (): WikiGraph => {
   }
 
   for (const post of posts) {
+    const sourceSlug = getCanonicalSlug(post.slugAsParams)
+
     for (const targetSlug of post.wikilinks) {
       const normalizedTargetSlug = normalizeWikiSlug(targetSlug)
       if (!normalizedTargetSlug) {
@@ -51,9 +57,9 @@ export const getGraph = (): WikiGraph => {
         })
       }
 
-      const key = `${post.slugAsParams}->${normalizedTargetSlug}`
+      const key = `${sourceSlug}->${normalizedTargetSlug}`
       links.set(key, {
-        source: post.slugAsParams,
+        source: sourceSlug,
         target: normalizedTargetSlug,
       })
     }
@@ -69,5 +75,9 @@ export const getGraph = (): WikiGraph => {
 
 export const getBacklinks = (slug: string): WikiPost[] => {
   const normalizedSlug = normalizeWikiSlug(slug)
+  if (!normalizedSlug) {
+    return []
+  }
+
   return getWikiPosts().filter((post) => post.wikilinks.includes(normalizedSlug))
 }

--- a/lib/wiki-graph.ts
+++ b/lib/wiki-graph.ts
@@ -4,6 +4,8 @@ import { normalizeWikiSlug } from '@/lib/wiki-slug'
 export type WikiGraphNode = {
   id: string
   label: string
+  slug: string
+  tags: string[]
   kind: 'wiki' | 'ghost'
 }
 
@@ -26,6 +28,8 @@ export const getGraph = (): WikiGraph => {
     nodes.set(post.slugAsParams, {
       id: post.slugAsParams,
       label: post.title,
+      slug: post.slugAsParams,
+      tags: post.tags,
       kind: 'wiki',
     })
   }
@@ -41,6 +45,8 @@ export const getGraph = (): WikiGraph => {
         nodes.set(normalizedTargetSlug, {
           id: normalizedTargetSlug,
           label: normalizedTargetSlug,
+          slug: normalizedTargetSlug,
+          tags: [],
           kind: 'ghost',
         })
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-force-graph-2d": "^1.29.1",
     "sugar-high": "^0.9.3",
     "tailwind-merge": "^2.5.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-force-graph-2d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@19.2.4)
       sugar-high:
         specifier: ^0.9.3
         version: 0.9.5
@@ -734,6 +737,9 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -954,6 +960,10 @@ packages:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1051,6 +1061,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1082,6 +1095,10 @@ packages:
 
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1147,6 +1164,82 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1513,9 +1606,17 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -1658,6 +1759,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1671,6 +1776,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1818,6 +1927,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -1849,6 +1962,10 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1948,6 +2065,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -2311,6 +2431,9 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2419,8 +2542,20 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -2720,6 +2855,9 @@ packages:
     resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
     engines: {node: '>=10'}
     hasBin: true
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -3446,6 +3584,8 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.0
 
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -3659,6 +3799,8 @@ snapshots:
 
   abbrev@2.0.0: {}
 
+  accessor-fn@1.5.3: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3771,6 +3913,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bezier-js@6.1.4: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3806,6 +3950,10 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001770: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
 
   ccount@2.0.1: {}
 
@@ -3858,6 +4006,83 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-binarytree@1.0.2: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-octree@1.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -4418,9 +4643,33 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.29.1
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
 
   foreground-child@3.3.1:
     dependencies:
@@ -4595,6 +4844,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  index-array-by@1.4.2: {}
+
   inherits@2.0.4: {}
 
   ini@4.1.3: {}
@@ -4606,6 +4857,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -4759,6 +5012,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jerrypick@1.1.2: {}
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
@@ -4785,6 +5040,10 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
 
   keyv@4.5.4:
     dependencies:
@@ -4864,6 +5123,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -5425,6 +5686,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  preact@10.29.1: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -5463,7 +5726,19 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-force-graph-2d@1.29.1(react@19.2.4):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-kapsule: 2.5.7(react@19.2.4)
+
   react-is@16.13.1: {}
+
+  react-kapsule@2.5.7(react@19.2.4):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 19.2.4
 
   react@19.2.4: {}
 
@@ -5874,6 +6149,8 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  tinycolor2@1.6.0: {}
 
   tinyglobby@0.2.15:
     dependencies:


### PR DESCRIPTION
## 작업 개요
`#47` 트래킹 이슈 기준으로 `#42`를 구현했습니다. Wiki 문서 간 연결을 `/wiki/graph`에서 인터랙티브하게 탐색할 수 있도록 그래프 뷰를 추가했습니다.

## 변경 사항
- `react-force-graph-2d` 의존성 추가
- `app/wiki/graph/page.tsx`를 플레이스홀더에서 실제 서버 페이지로 교체
  - `getGraph()` 결과를 클라이언트 그래프 컴포넌트로 전달
- `components/widget/wiki-graph-canvas.tsx` 신규 추가
  - `next/dynamic`으로 SSR off된 그래프 렌더링
  - 노드 호버 시 인접 노드/링크 강조, 비인접 요소 흐림 처리
  - 노드 클릭 시 `/wiki/<slug>` 이동
  - 좌상단 태그 체크박스 필터 + 색상 범례
  - 상단 검색창으로 slug/title 부분 매칭 후 노드 zoom
  - `next-themes` 기반 라이트/다크 모드 색상 연동
  - 헤더 아래 영역을 기준으로 뷰포트 높이를 계산해 그래프 캔버스 렌더링
- `lib/wiki-graph.ts` 그래프 노드 스키마 확장
  - 노드에 `slug`, `tags` 포함
- `/wiki` 인덱스의 graph 진입 링크 문구에서 준비중 placeholder 제거

## 검증
- `pnpm build` 통과

## 관련 이슈
- Closes #42
- Ref #47
