### PR TITLE
[#46] 빌드/타입체크/린트 및 정적 export 최종 검증

### DIFF
--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -47,7 +47,7 @@ export default function LayoutBlogPost({
 }) {
   return (
     <>
-      <div className="pointer-events-none fixed left-0 top-0 z-10 h-12 w-full bg-gray-100 to-transparent backdrop-blur-xl [-webkit-mask-image:linear-gradient(to_bottom,black,transparent)] dark:bg-zinc-950" />
+      <div className="pointer-events-none fixed top-0 left-0 z-10 h-12 w-full bg-gray-100 to-transparent backdrop-blur-xl [-webkit-mask-image:linear-gradient(to_bottom,black,transparent)] dark:bg-zinc-950" />
       <ScrollProgress
         className="fixed top-0 z-20 h-0.5 bg-gray-300 dark:bg-zinc-600"
         springOptions={{
@@ -55,10 +55,10 @@ export default function LayoutBlogPost({
         }}
       />
 
-      <div className="absolute right-4 top-24">
+      <div className="absolute top-24 right-4">
         <CopyButton />
       </div>
-      <main className="prose prose-gray mt-24 pb-20 prose-h4:prose-base prose-pre:border prose-pre:border-zinc-200 prose-pre:bg-zinc-100 prose-pre:text-zinc-800 dark:prose-invert dark:prose-pre:border-zinc-800 dark:prose-pre:bg-zinc-900 dark:prose-pre:text-zinc-100 prose-h1:text-xl prose-h1:font-medium prose-h2:mt-12 prose-h2:scroll-m-20 prose-h2:text-lg prose-h2:font-medium prose-h3:text-base prose-h3:font-medium prose-h4:font-medium prose-h5:text-base prose-h5:font-medium prose-h6:text-base prose-h6:font-medium prose-strong:font-medium">
+      <main className="prose prose-gray prose-h4:prose-base prose-pre:border prose-pre:border-zinc-200 prose-pre:bg-zinc-100 prose-pre:text-zinc-800 dark:prose-invert dark:prose-pre:border-zinc-800 dark:prose-pre:bg-zinc-900 dark:prose-pre:text-zinc-100 prose-h1:text-xl prose-h1:font-medium prose-h2:mt-12 prose-h2:scroll-m-20 prose-h2:text-lg prose-h2:font-medium prose-h3:text-base prose-h3:font-medium prose-h4:font-medium prose-h5:text-base prose-h5:font-medium prose-h6:text-base prose-h6:font-medium prose-strong:font-medium mt-24 pb-20">
         {children}
       </main>
     </>

--- a/app/wiki/[slug]/page.tsx
+++ b/app/wiki/[slug]/page.tsx
@@ -37,9 +37,11 @@ export default async function WikiDetailPage({ params }: WikiDetailPageProps) {
           {'<'} Wiki
         </Link>
       </div>
-      <article className="prose prose-gray max-w-none dark:prose-invert prose-h1:text-xl prose-h1:font-medium prose-h2:mt-12 prose-h2:text-lg prose-h2:font-medium prose-h3:text-base prose-h3:font-medium prose-pre:border prose-pre:border-zinc-200 prose-pre:bg-zinc-100 prose-pre:text-zinc-800 dark:prose-pre:border-zinc-800 dark:prose-pre:bg-zinc-900 dark:prose-pre:text-zinc-100">
+      <article className="prose prose-gray dark:prose-invert prose-h1:text-xl prose-h1:font-medium prose-h2:mt-12 prose-h2:text-lg prose-h2:font-medium prose-h3:text-base prose-h3:font-medium prose-pre:border prose-pre:border-zinc-200 prose-pre:bg-zinc-100 prose-pre:text-zinc-800 dark:prose-pre:border-zinc-800 dark:prose-pre:bg-zinc-900 dark:prose-pre:text-zinc-100 max-w-none">
         <h1>{post.title}</h1>
-        {post.description && <p className="mt-2 text-zinc-600">{post.description}</p>}
+        {post.description && (
+          <p className="mt-2 text-zinc-600">{post.description}</p>
+        )}
         <div className="mt-4 flex flex-wrap gap-2">
           {post.tags.map((tag) => (
             <span
@@ -67,7 +69,9 @@ export default async function WikiDetailPage({ params }: WikiDetailPageProps) {
         {backlinks.length > 0 && (
           <ul className="mt-3 space-y-2">
             {backlinks.map((backlink) => (
-              <li key={`${post.slugAsParams}-backlink-${backlink.slugAsParams}`}>
+              <li
+                key={`${post.slugAsParams}-backlink-${backlink.slugAsParams}`}
+              >
                 <Link
                   href={`/wiki/${backlink.slugAsParams}`}
                   className="text-sm text-zinc-700 underline-offset-2 transition-colors hover:text-zinc-900 hover:underline dark:text-zinc-300 dark:hover:text-zinc-100"

--- a/app/wiki/graph/page.tsx
+++ b/app/wiki/graph/page.tsx
@@ -3,7 +3,8 @@ import { getGraph } from '@/lib/wiki-graph'
 
 export const metadata = {
   title: 'Wiki Graph',
-  description: 'Wiki 문서 간 연결 구조를 인터랙티브 그래프로 탐색할 수 있습니다.',
+  description:
+    'Wiki 문서 간 연결 구조를 인터랙티브 그래프로 탐색할 수 있습니다.',
   alternates: {
     canonical: '/wiki/graph',
   },

--- a/app/wiki/wiki-list.tsx
+++ b/app/wiki/wiki-list.tsx
@@ -49,7 +49,9 @@ export function WikiList({ posts, tags }: WikiListProps) {
             key={tag}
             type="button"
             aria-pressed={selectedTag === tag}
-            onClick={() => setSelectedTag((prevTag) => (prevTag === tag ? null : tag))}
+            onClick={() =>
+              setSelectedTag((prevTag) => (prevTag === tag ? null : tag))
+            }
             className={`rounded-full border px-3 py-1 text-xs transition-colors ${
               selectedTag === tag
                 ? 'border-zinc-900 bg-zinc-900 text-zinc-50 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900'
@@ -78,7 +80,9 @@ export function WikiList({ posts, tags }: WikiListProps) {
               data-id={post.slug}
             >
               <div className="flex flex-col gap-2">
-                <h4 className="m-0! font-normal dark:text-zinc-100">{post.title}</h4>
+                <h4 className="m-0! font-normal dark:text-zinc-100">
+                  {post.title}
+                </h4>
                 <div className="flex flex-wrap gap-2">
                   {post.tags.map((tag) => (
                     <span
@@ -90,8 +94,12 @@ export function WikiList({ posts, tags }: WikiListProps) {
                   ))}
                 </div>
                 <p className="mb-0! flex flex-col gap-1 text-zinc-500 dark:text-zinc-400">
-                  {post.description && <span className="text-sm">{post.description}</span>}
-                  <span className="text-xs">{formatWikiDate(post.updatedAt)}</span>
+                  {post.description && (
+                    <span className="text-sm">{post.description}</span>
+                  )}
+                  <span className="text-xs">
+                    {formatWikiDate(post.updatedAt)}
+                  </span>
                 </p>
               </div>
             </Link>

--- a/components/ui/animated-background.tsx
+++ b/components/ui/animated-background.tsx
@@ -59,7 +59,7 @@ export function AnimatedBackground({
 
   return Children.map(
     children,
-    (child: ReactElement<AnimatedBackgroundChildProps>, index) => {
+    (child: ReactElement<AnimatedBackgroundChildProps>) => {
       const id = child.props['data-id']
 
       const interactionProps = enableHover
@@ -74,7 +74,7 @@ export function AnimatedBackground({
       return cloneElement(
         child,
         {
-          key: index,
+          key: id,
           className: cn('relative inline-flex', child.props.className),
           'data-checked': activeId === id ? 'true' : 'false',
           ...interactionProps,

--- a/components/ui/animated-background.tsx
+++ b/components/ui/animated-background.tsx
@@ -4,16 +4,27 @@ import { AnimatePresence, Transition, motion } from 'motion/react'
 import {
   Children,
   cloneElement,
+  type ReactNode,
   ReactElement,
   useEffect,
-  useState,
   useId,
+  useState,
 } from 'react'
+
+type AnimatedBackgroundChildProps = {
+  'data-id': string
+  className?: string
+  children?: ReactNode
+  'data-checked'?: 'true' | 'false'
+  onClick?: () => void
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+}
 
 export type AnimatedBackgroundProps = {
   children:
-    | ReactElement<{ 'data-id': string }>[]
-    | ReactElement<{ 'data-id': string }>
+    | ReactElement<AnimatedBackgroundChildProps>[]
+    | ReactElement<AnimatedBackgroundChildProps>
   defaultValue?: string
   onValueChange?: (newActiveId: string | null) => void
   className?: string
@@ -46,45 +57,48 @@ export function AnimatedBackground({
     }
   }, [defaultValue])
 
-  return Children.map(children, (child: any, index) => {
-    const id = child.props['data-id']
+  return Children.map(
+    children,
+    (child: ReactElement<AnimatedBackgroundChildProps>, index) => {
+      const id = child.props['data-id']
 
-    const interactionProps = enableHover
-      ? {
-          onMouseEnter: () => handleSetActiveId(id),
-          onMouseLeave: () => handleSetActiveId(null),
-        }
-      : {
-          onClick: () => handleSetActiveId(id),
-        }
+      const interactionProps = enableHover
+        ? {
+            onMouseEnter: () => handleSetActiveId(id),
+            onMouseLeave: () => handleSetActiveId(null),
+          }
+        : {
+            onClick: () => handleSetActiveId(id),
+          }
 
-    return cloneElement(
-      child,
-      {
-        key: index,
-        className: cn('relative inline-flex', child.props.className),
-        'data-checked': activeId === id ? 'true' : 'false',
-        ...interactionProps,
-      },
-      <>
-        <AnimatePresence initial={false}>
-          {activeId === id && (
-            <motion.div
-              layoutId={`background-${uniqueId}`}
-              className={cn('absolute inset-0', className)}
-              transition={transition}
-              initial={{ opacity: defaultValue ? 1 : 0 }}
-              animate={{
-                opacity: 1,
-              }}
-              exit={{
-                opacity: 0,
-              }}
-            />
-          )}
-        </AnimatePresence>
-        <div className="z-10">{child.props.children}</div>
-      </>,
-    )
-  })
+      return cloneElement(
+        child,
+        {
+          key: index,
+          className: cn('relative inline-flex', child.props.className),
+          'data-checked': activeId === id ? 'true' : 'false',
+          ...interactionProps,
+        },
+        <>
+          <AnimatePresence initial={false}>
+            {activeId === id && (
+              <motion.div
+                layoutId={`background-${uniqueId}`}
+                className={cn('absolute inset-0', className)}
+                transition={transition}
+                initial={{ opacity: defaultValue ? 1 : 0 }}
+                animate={{
+                  opacity: 1,
+                }}
+                exit={{
+                  opacity: 0,
+                }}
+              />
+            )}
+          </AnimatePresence>
+          <div className="z-10">{child.props.children}</div>
+        </>,
+      )
+    },
+  )
 }

--- a/components/ui/text-effect.tsx
+++ b/components/ui/text-effect.tsx
@@ -177,7 +177,8 @@ const createVariantsWithTransition = (
 ): Variants => {
   if (!transition) return baseVariants
 
-  const { exit: _, ...mainTransition } = transition
+  const { exit, ...mainTransition } = transition
+  void exit
 
   return {
     ...baseVariants,

--- a/components/widget/wiki-graph-canvas.tsx
+++ b/components/widget/wiki-graph-canvas.tsx
@@ -4,6 +4,7 @@ import type { WikiGraph, WikiGraphNode } from '@/lib/wiki-graph'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
+import type { ForceGraphMethods } from 'react-force-graph-2d'
 import {
   type FormEvent,
   useCallback,
@@ -13,7 +14,9 @@ import {
   useState,
 } from 'react'
 
-const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), { ssr: false })
+const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
+  ssr: false,
+})
 
 const LIGHT_TAG_COLORS = [
   '#0d9488',
@@ -76,20 +79,30 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
   const { resolvedTheme } = useTheme()
 
   const isDark = resolvedTheme === 'dark'
-  const graphRef = useRef<any>(undefined)
+  const graphRef = useRef<ForceGraphMethods | undefined>(undefined)
   const containerRef = useRef<HTMLDivElement>(null)
 
   const [canvasWidth, setCanvasWidth] = useState(0)
   const [canvasHeight, setCanvasHeight] = useState(0)
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null)
-  const [highlightedNodeIds, setHighlightedNodeIds] = useState<Set<string>>(new Set())
-  const [highlightedLinkIds, setHighlightedLinkIds] = useState<Set<string>>(new Set())
+  const [highlightedNodeIds, setHighlightedNodeIds] = useState<Set<string>>(
+    new Set(),
+  )
+  const [highlightedLinkIds, setHighlightedLinkIds] = useState<Set<string>>(
+    new Set(),
+  )
   const [searchKeyword, setSearchKeyword] = useState('')
   const [searchMessage, setSearchMessage] = useState('')
   const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null)
 
-  const nodes = useMemo<GraphNode[]>(() => graph.nodes.map((node) => ({ ...node })), [graph.nodes])
-  const links = useMemo<GraphLink[]>(() => graph.links.map((link) => ({ ...link })), [graph.links])
+  const nodes = useMemo<GraphNode[]>(
+    () => graph.nodes.map((node) => ({ ...node })),
+    [graph.nodes],
+  )
+  const links = useMemo<GraphLink[]>(
+    () => graph.links.map((link) => ({ ...link })),
+    [graph.links],
+  )
 
   const tags = useMemo(() => {
     return [...new Set(nodes.flatMap((node) => node.tags))].sort((a, b) =>
@@ -221,7 +234,9 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
   const tagColorMap = useMemo(() => {
     const palette = isDark ? DARK_TAG_COLORS : LIGHT_TAG_COLORS
 
-    return new Map(tags.map((tag, index) => [tag, palette[index % palette.length]]))
+    return new Map(
+      tags.map((tag, index) => [tag, palette[index % palette.length]]),
+    )
   }, [isDark, tags])
 
   const graphData = useMemo(
@@ -232,7 +247,7 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
     [links, nodes],
   )
 
-  const nodeLabel = useCallback((node: any) => {
+  const nodeLabel = useCallback((node: unknown) => {
     const item = node as GraphNode
     if (item.kind === 'ghost') {
       return `${item.slug} (미작성)`
@@ -248,29 +263,35 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
         return isDark ? '#52525b' : '#a1a1aa'
       }
 
-      const matchingTag = node.tags.find((tag) => enabledTagSet.has(tag)) ?? node.tags[0]
+      const matchingTag =
+        node.tags.find((tag) => enabledTagSet.has(tag)) ?? node.tags[0]
       const fallbackColor = isDark ? '#60a5fa' : '#2563eb'
 
-      return matchingTag ? (tagColorMap.get(matchingTag) ?? fallbackColor) : fallbackColor
+      return matchingTag
+        ? (tagColorMap.get(matchingTag) ?? fallbackColor)
+        : fallbackColor
     },
     [enabledTagSet, isDark, tagColorMap],
   )
 
   const handleNodeHover = useCallback(
-    (node: any | null) => {
-      if (!node || !node.id) {
+    (node: unknown | null) => {
+      const hoveredNode = node as { id?: string | number } | null
+      if (!hoveredNode?.id) {
         setHoveredNodeId(null)
         setHighlightedNodeIds(new Set())
         setHighlightedLinkIds(new Set())
         return
       }
 
-      const id = String(node.id)
+      const id = String(hoveredNode.id)
       setHoveredNodeId(id)
 
       const neighborIds = neighborsByNodeId.get(id) ?? new Set<string>()
       const nodeSet = new Set<string>([id, ...neighborIds])
-      const linkSet = new Set<string>(linksByNodeId.get(id) ?? new Set<string>())
+      const linkSet = new Set<string>(
+        linksByNodeId.get(id) ?? new Set<string>(),
+      )
 
       setHighlightedNodeIds(nodeSet)
       setHighlightedLinkIds(linkSet)
@@ -292,7 +313,10 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
           return
         }
 
-        if (typeof targetNode.x === 'number' && typeof targetNode.y === 'number') {
+        if (
+          typeof targetNode.x === 'number' &&
+          typeof targetNode.y === 'number'
+        ) {
           graphApi.centerAt(targetNode.x, targetNode.y, 700)
           graphApi.zoom(3.5, 700)
           return
@@ -324,7 +348,8 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
         }
 
         return (
-          node.slug.toLowerCase().includes(keyword) || node.label.toLowerCase().includes(keyword)
+          node.slug.toLowerCase().includes(keyword) ||
+          node.label.toLowerCase().includes(keyword)
         )
       })
 
@@ -345,16 +370,18 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
   )
 
   const nodeVisibility = useCallback(
-    (node: any) => {
-      return visibleNodeIds.has(String(node.id))
+    (node: unknown) => {
+      const graphNode = node as { id?: string | number }
+      return visibleNodeIds.has(String(graphNode.id ?? ''))
     },
     [visibleNodeIds],
   )
 
   const linkVisibility = useCallback(
-    (link: any) => {
-      const sourceId = getNodeId(link.source)
-      const targetId = getNodeId(link.target)
+    (link: unknown) => {
+      const graphLink = link as { source?: unknown; target?: unknown }
+      const sourceId = getNodeId(graphLink.source)
+      const targetId = getNodeId(graphLink.target)
 
       return visibleNodeIds.has(sourceId) && visibleNodeIds.has(targetId)
     },
@@ -362,12 +389,14 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
   )
 
   const nodeCanvasObject = useCallback(
-    (node: any, context: CanvasRenderingContext2D, globalScale: number) => {
+    (node: unknown, context: CanvasRenderingContext2D, globalScale: number) => {
       const item = node as GraphNode
       const nodeId = String(item.id)
 
       const isHighlighted =
-        hoveredNodeId === null || highlightedNodeIds.size === 0 ? true : highlightedNodeIds.has(nodeId)
+        hoveredNodeId === null || highlightedNodeIds.size === 0
+          ? true
+          : highlightedNodeIds.has(nodeId)
       const isFocused = focusedNodeId === nodeId
 
       const radius = item.kind === 'ghost' ? 3.5 : 5.5
@@ -391,7 +420,8 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
         context.closePath()
       }
 
-      const showLabel = isFocused || nodeId === hoveredNodeId || globalScale > 2.2
+      const showLabel =
+        isFocused || nodeId === hoveredNodeId || globalScale > 2.2
       if (showLabel) {
         const fontSize = Math.max(11, 14 / globalScale)
         const text = item.kind === 'ghost' ? item.slug : item.label
@@ -403,8 +433,15 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
         context.textBaseline = 'middle'
 
         const textWidth = context.measureText(text).width
-        context.fillStyle = isDark ? 'rgba(9, 9, 11, 0.82)' : 'rgba(255, 255, 255, 0.82)'
-        context.fillRect(textX - 2, textY - fontSize * 0.65, textWidth + 4, fontSize * 1.3)
+        context.fillStyle = isDark
+          ? 'rgba(9, 9, 11, 0.82)'
+          : 'rgba(255, 255, 255, 0.82)'
+        context.fillRect(
+          textX - 2,
+          textY - fontSize * 0.65,
+          textWidth + 4,
+          fontSize * 1.3,
+        )
 
         context.fillStyle = isDark ? '#f4f4f5' : '#18181b'
         context.globalAlpha = opacity
@@ -413,16 +450,25 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
 
       context.restore()
     },
-    [focusedNodeId, getNodeFillColor, highlightedNodeIds, hoveredNodeId, isDark],
+    [
+      focusedNodeId,
+      getNodeFillColor,
+      highlightedNodeIds,
+      hoveredNodeId,
+      isDark,
+    ],
   )
 
   const linkColor = useCallback(
-    (link: any) => {
-      const sourceId = getNodeId(link.source)
-      const targetId = getNodeId(link.target)
+    (link: unknown) => {
+      const graphLink = link as { source?: unknown; target?: unknown }
+      const sourceId = getNodeId(graphLink.source)
+      const targetId = getNodeId(graphLink.target)
       const linkId = `${sourceId}->${targetId}`
       const isHighlighted =
-        hoveredNodeId === null || highlightedLinkIds.size === 0 ? true : highlightedLinkIds.has(linkId)
+        hoveredNodeId === null || highlightedLinkIds.size === 0
+          ? true
+          : highlightedLinkIds.has(linkId)
 
       if (!isHighlighted) {
         return isDark ? 'rgba(82, 82, 91, 0.18)' : 'rgba(113, 113, 122, 0.18)'
@@ -434,9 +480,10 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
   )
 
   const linkWidth = useCallback(
-    (link: any) => {
-      const sourceId = getNodeId(link.source)
-      const targetId = getNodeId(link.target)
+    (link: unknown) => {
+      const graphLink = link as { source?: unknown; target?: unknown }
+      const sourceId = getNodeId(graphLink.source)
+      const targetId = getNodeId(graphLink.target)
       const linkId = `${sourceId}->${targetId}`
 
       if (hoveredNodeId === null || highlightedLinkIds.size === 0) {
@@ -454,7 +501,10 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
     <div ref={containerRef} className="relative -mx-4">
       <div
         className="relative w-full border-y border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950"
-        style={{ height: canvasHeight > 0 ? `${canvasHeight}px` : 'calc(100vh - 10rem)' }}
+        style={{
+          height:
+            canvasHeight > 0 ? `${canvasHeight}px` : 'calc(100vh - 10rem)',
+        }}
       >
         <form
           onSubmit={handleSearch}
@@ -478,7 +528,7 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
 
         <aside className="absolute top-4 left-4 z-10 max-h-[min(70vh,34rem)] w-64 overflow-auto rounded-2xl border border-zinc-300 bg-white/92 p-3 backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/88">
           <div className="mb-2 flex items-center justify-between">
-            <h2 className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+            <h2 className="text-xs font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
               Tag Filter
             </h2>
             <div className="flex items-center gap-1 text-[10px]">
@@ -553,7 +603,7 @@ export function WikiGraphCanvas({ graph }: WikiGraphCanvasProps) {
             cooldownTicks={120}
             d3VelocityDecay={0.22}
             onNodeHover={handleNodeHover}
-            onNodeClick={(node) => {
+            onNodeClick={(node: unknown) => {
               const item = node as GraphNode
               if (item.kind === 'wiki') {
                 router.push(`/wiki/${item.slug}`)

--- a/lib/wiki-graph.ts
+++ b/lib/wiki-graph.ts
@@ -66,9 +66,14 @@ export const getGraph = (): WikiGraph => {
   }
 
   return {
-    nodes: [...nodes.values()].sort((a, b) => a.id.localeCompare(b.id, 'ko-KR')),
+    nodes: [...nodes.values()].sort((a, b) =>
+      a.id.localeCompare(b.id, 'ko-KR'),
+    ),
     links: [...links.values()].sort((a, b) =>
-      `${a.source}->${a.target}`.localeCompare(`${b.source}->${b.target}`, 'ko-KR'),
+      `${a.source}->${a.target}`.localeCompare(
+        `${b.source}->${b.target}`,
+        'ko-KR',
+      ),
     ),
   }
 }
@@ -79,5 +84,7 @@ export const getBacklinks = (slug: string): WikiPost[] => {
     return []
   }
 
-  return getWikiPosts().filter((post) => post.wikilinks.includes(normalizedSlug))
+  return getWikiPosts().filter((post) =>
+    post.wikilinks.includes(normalizedSlug),
+  )
 }

--- a/lib/wiki-posts.ts
+++ b/lib/wiki-posts.ts
@@ -18,9 +18,7 @@ export const getWikiPosts = () => {
       slugAsParams: toSlugAsParams(post.slug),
     }))
     .sort((a, b) => {
-      return (
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-      )
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
     })
 }
 
@@ -29,7 +27,7 @@ export const getWikiPost = (slug: string) => {
 }
 
 export const getWikiTags = () => {
-  return [...new Set(getWikiPosts().flatMap((post) => post.tags))].sort((a, b) =>
-    a.localeCompare(b, 'ko-KR'),
+  return [...new Set(getWikiPosts().flatMap((post) => post.tags))].sort(
+    (a, b) => a.localeCompare(b, 'ko-KR'),
   )
 }


### PR DESCRIPTION
## 관련 이슈
- #46
- #47 (Tracking)

## 작업 내용
`#47` 트래킹 이슈의 마지막 단계(`#46`) 기준으로 최종 검증이 가능하도록 정리했습니다.

- 린트 실패 원인이던 포맷 불일치(Prettier) 반영
- `no-explicit-any`, `no-unused-vars` 오류가 나던 컴포넌트 타입 정리
  - `components/widget/wiki-graph-canvas.tsx`
  - `components/ui/animated-background.tsx`
  - `components/ui/text-effect.tsx`
- 위 수정으로 `pnpm typecheck`, `pnpm lint`, `pnpm build`가 통과되도록 안정화

## 검증 결과
아래 항목을 로컬에서 확인했습니다.

- `pnpm typecheck` 통과
- `pnpm lint` 통과 (기존 `components/ui/magnetic.tsx`의 hook dependency warning 1건은 유지)
- `pnpm build` 성공 (`velite build && next build`)
- `out/` 산출물 경로 검증 스크립트 통과
  - `/`, `/blog`, `/blog/<slug>`, `/books`, `/books/<slug>`, `/wiki`, `/wiki/<slug>`, `/wiki/graph` 모두 존재
- `out/` 내 `/logs/*` 산출물 없음
- 정적 서버에서 `/wiki/graph.html` 스폿 체크
  - 페이지 타이틀 정상
  - `canvasCount: 1`, 검색 입력/태그 필터 UI 렌더 확인

## 참고
- 이번 PR은 기능 추가보다는 최종 릴리즈 검증 단계에서 드러난 빌드/린트/타입 안정성 이슈를 함께 정리한 내용입니다.
